### PR TITLE
Lower required Android version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
 
 // End of strings reserved for F-Droid patch
-        minSdkVersion 16
+        minSdkVersion 10
         targetSdkVersion 26
 
         versionCode 60000

--- a/app/src/main/java/net/basov/lws/PreferencesActivity.java
+++ b/app/src/main/java/net/basov/lws/PreferencesActivity.java
@@ -166,12 +166,12 @@ public class PreferencesActivity extends PreferenceActivity implements
                         Toast.LENGTH_LONG
                 ).show();
                 Log.w("lWS", "Document root doesn't exists. Set to default.");
-                prefEdit.putString(getString(R.string.pk_document_root), defaultDocumentRoot).apply();
+                prefEdit.putString(getString(R.string.pk_document_root), defaultDocumentRoot).commit();
             } else if (documentRoot.charAt(docRootLength - 1) != '/') {
                 // existing directory readable with and without trailing slash
                 // but slash need for correct filename forming
                 documentRoot = documentRoot + "/";
-                prefEdit.putString(getString(R.string.pk_document_root), documentRoot).apply();
+                prefEdit.putString(getString(R.string.pk_document_root), documentRoot).commit();
             }
             prefEdit.putBoolean(getString(R.string.pk_pref_changed), true).commit();
             pref.setSummary(documentRoot);
@@ -195,7 +195,7 @@ public class PreferencesActivity extends PreferenceActivity implements
                         Toast.LENGTH_LONG
                 ).show();
                 Log.w("lWS", "Port less then 1024 or grate then 65535. Set to default.");
-                prefEdit.putString(getString(R.string.pk_port), portAsString).apply();
+                prefEdit.putString(getString(R.string.pk_port), portAsString).commit();
             }
             prefEdit.putBoolean(getString(R.string.pk_pref_changed), true).commit();
             pref.setSummary(portAsString);

--- a/app/src/main/java/net/basov/lws/ServerService.java
+++ b/app/src/main/java/net/basov/lws/ServerService.java
@@ -37,6 +37,7 @@ import android.net.wifi.SupplicantState;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
@@ -223,18 +224,19 @@ public class ServerService extends Service {
                 stopIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT
         );
-        Notification notification = new Notification.Builder(this)
-                .setSmallIcon(R.mipmap.lws_ic)
-                .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.mipmap.lws_ic))
-                .setContentTitle(getString(R.string.app_name))
-                .setContentText(message)
-                .setWhen(System.currentTimeMillis())
-                .setContentIntent(contentIntent)
-                .addAction(0, "Stop service", stopPendingIntent)
-                .setOngoing(true)
-                .build();
-        startForeground(NOTIFICATION_ID, notification);
-
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            Notification notification = new Notification.Builder(this)
+                    .setSmallIcon(R.mipmap.lws_ic)
+                    .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.mipmap.lws_ic))
+                    .setContentTitle(getString(R.string.app_name))
+                    .setContentText(message)
+                    .setWhen(System.currentTimeMillis())
+                    .setContentIntent(contentIntent)
+                    .addAction(0, "Stop service", stopPendingIntent)
+                    .setOngoing(true)
+                    .build();
+            startForeground(NOTIFICATION_ID, notification);
+        }
     }
 
     @Override


### PR DESCRIPTION
Having a web server on the phone is really important for old phones as more complicated applications for synchronizing files do not work for them (Syncthing, nextCloud, ...). HTTP-Servers are an easy way to exchange files peer to peer.

I have an old phone and reduced the android version so that the server runs on it.

Changes:
- minAPK version
- remove notifications if they are not available
- use commit instead of apply

I kindly request a merge of this to provide a means of sharing files to underprivileged users with old phones.